### PR TITLE
*: fix tunnelling race condition, cleanup, bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: ## Run all the linters
 ci: lint test ## Run all the tests and code checks
 
 build: ## Build a beta version
-	go build -o skipper ./main.go
+	go build -o skipper ./
 
 #install: ## Install to $GOPATH/src
 #	go install ./cmd/...

--- a/aws/ec2client/ec2client.go
+++ b/aws/ec2client/ec2client.go
@@ -14,8 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-var instance *Ec2client
-var once sync.Once
+var (
+	instance *Ec2client
+	once     sync.Once
+)
 
 // Ec2client type
 type Ec2client struct {
@@ -228,7 +230,7 @@ func (c *Ec2client) StartInstance(startInstanceInput *StartInstanceInput) (*ec2.
 	if err != nil {
 		return nil, fmt.Errorf("Some error happened creating the instance: %s", err)
 	}
-	log.Println("Created instance", *runResult.Instances[0].InstanceId)
+	c.logger.Println("Created instance", *runResult.Instances[0].InstanceId)
 
 	// Add tags to the created instance
 	_, errtag := c.svc.CreateTags(&ec2.CreateTagsInput{
@@ -241,7 +243,7 @@ func (c *Ec2client) StartInstance(startInstanceInput *StartInstanceInput) (*ec2.
 		},
 	})
 	if errtag != nil {
-		return nil, fmt.Errorf("Could not create tags for instance", runResult.Instances[0].InstanceId, errtag)
+		return nil, fmt.Errorf("Could not create tags for instance %s: %v", runResult.Instances[0].InstanceId, errtag)
 
 	}
 
@@ -250,7 +252,7 @@ func (c *Ec2client) StartInstance(startInstanceInput *StartInstanceInput) (*ec2.
 	describeInstanceInput := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{runResult.Instances[0].InstanceId},
 	}
-	c.logger.Println("Wait until the instance exist")
+	c.logger.Println("Waiting until the instance exists")
 
 	waiterr := c.svc.WaitUntilInstanceRunning(describeInstanceInput)
 	if waiterr != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1,30 +1,35 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/viper"
 )
 
-var pullTag string
-var crossPullActivated bool
-var testCommand string
-var forceBuild = false
+var (
+	pullTag            string
+	crossPullActivated bool
+	testCommand        string
+	forceBuild         = false
 
-var config = ""
+	config = ""
+)
 
-func Init() {
+func Init() error {
 
 	viper.SetConfigName("config")         // name of config file (without extension)
 	viper.AddConfigPath("/etc/skipper/")  // path to look for the config file in
 	viper.AddConfigPath("$HOME/.skipper") // call multiple times to add many search paths
 	err := viper.ReadInConfig()           // Find and read the config file
-	if err != nil {
-		fmt.Println("Failed to read config", err)
+	switch err.(type) {
+	case viper.ConfigFileNotFoundError:
+		err = nil
 	}
-
+	if err != nil {
+		return err
+	}
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
+	return nil
 }

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -65,8 +65,8 @@ func UnixHome() (string, error) {
 			}
 		}
 	}
-
 	out.Reset()
+
 	cmd = exec.Command("sh", "-c", "cd && pwd")
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
@@ -74,9 +74,9 @@ func UnixHome() (string, error) {
 	}
 
 	res := strings.TrimSpace(out.String())
-	if res == "" {
-		return "", errors.New("We cannot not find a dir")
+	if res != "" {
+		return res, nil
 	}
 
-	return res, nil
+	return "", errors.New("cannot find a home directory for current user")
 }

--- a/listservices.go
+++ b/listservices.go
@@ -1,14 +1,31 @@
 package main
 
-import "github.com/spf13/cobra"
-import "github.com/blinkist/skipper/aws/ecsclient"
-import "fmt"
-import "sort"
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/blinkist/skipper/aws/ecsclient"
+)
+
+func init() {
+	RootCmd.AddCommand(servicesListCmd)
+
+}
 
 func listServices() {
 	ecs := ecsclient.New()
-	clusters, _ := ecs.GetClusterNames()
+	clusters, err := ecs.GetClusterNames()
+	if err != nil {
+		panic(fmt.Sprintf("unhandled error: %v", err))
+	}
 	sort.Strings(clusters)
+	if len(clusters) < 0 {
+		fmt.Printf("no clusters found\n")
+		os.Exit(0)
+	}
 
 	for _, cluster := range clusters {
 		services, _ := ecs.ListServices(&cluster)
@@ -30,8 +47,4 @@ var servicesListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		listServices()
 	},
-}
-
-func init() {
-	RootCmd.AddCommand(servicesListCmd)
 }

--- a/main.go
+++ b/main.go
@@ -4,26 +4,31 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/blinkist/skipper/config"
 	"github.com/spf13/cobra"
+
+	"github.com/blinkist/skipper/config"
 )
 
-var cfgFile string
-
 var (
+	cfgFile string
+
 	argService     string
 	argServiceType string
 	argTimeout     int
+
+	RootCmd = &cobra.Command{
+		Use:     "skipper",
+		Short:   "Helper tools for Amazon's Elastic Container Service",
+		Long:    `Skipper is a command-line tool to help working with Amazon ECS clusters`,
+		Version: "0.0.1",
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		//	Run: func(cmd *cobra.Command, args []string) { },
+	}
 )
 
-// RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
-	Use:   "skipper",
-	Short: "Helper tools for Amazon's Elastic Container Service",
-	Long:  `Wraps the ECS SDK in a more user-friendly (for me at least) way`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+func init() {
+	RootCmd.Flags().IntVarP(&argTimeout, "timeout", "", 300, "Default timeout for task replacement.")
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -36,10 +41,9 @@ func Execute() {
 }
 
 func main() {
+	if err := config.Init(); err != nil {
+		fmt.Println("error initialising config:", err)
+		os.Exit(1)
+	}
 	Execute()
-}
-
-func init() {
-	config.Init()
-	RootCmd.Flags().IntVarP(&argTimeout, "timeout", "", 300, "Default timeout for task replacement.")
 }

--- a/shell_cmd.go
+++ b/shell_cmd.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	//"bytes"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
-
-	"golang.org/x/crypto/ssh"
 )
-
-var session *ssh.Session
-var exitTimeStamp int32
 
 var tunnelCmd = &cobra.Command{
 	Use:   "tunnel [service]",
@@ -18,24 +14,22 @@ var tunnelCmd = &cobra.Command{
 TUNNELLL
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		InvokeShell()
+		err := InvokeShell()
+		if err != nil {
+			fmt.Printf("error invoking shell: %v", err)
+			os.Exit(-1)
+		}
 	},
 }
 
 var shellCmd = &cobra.Command{
-	Use:   "shell [service]",
-	Short: "empty",
-	Long: `
-
-`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-	},
+	Use:   "shell <subcommand>",
+	Short: "Shell commands",
 }
 
 var setkeypairCmd = &cobra.Command{
 	Use:   "setkeypair [service]",
-	Short: "Secure Shell into one of the service container instances' EC2 host machines",
+	Short: "Create a temporary EC2 keypair for the current user",
 	Long: `
 Lets say you have a service running a few container instances on various hosts.
 Lets say you also need to debug some file configuration running in the container,
@@ -48,12 +42,9 @@ yourself! Yay. I guess.
 	},
 }
 
-var listinstancesCmd = &cobra.Command{
-	Use:   "listinstances [service]",
-	Short: "We purge the keypair on both filesystem and AWS",
-	Long: `
-	We purge the keypair on both filesystem and AWS
-`,
+var purgeKeypairCmd = &cobra.Command{
+	Use:   "purgekeypair [service]",
+	Short: "Purge the current user's keypair on both filesystem and AWS",
 	Run: func(cmd *cobra.Command, args []string) {
 		// //		ec2client_ := ec2client.New()
 
@@ -74,10 +65,8 @@ var listinstancesCmd = &cobra.Command{
 }
 
 func init() {
-	exitTimeStamp = 0
 	RootCmd.AddCommand(shellCmd)
 	shellCmd.AddCommand(setkeypairCmd)
-	shellCmd.AddCommand(listinstancesCmd)
+	shellCmd.AddCommand(purgeKeypairCmd)
 	shellCmd.AddCommand(tunnelCmd)
-
 }

--- a/skipper.go
+++ b/skipper.go
@@ -50,7 +50,10 @@ var skipperUploadCmd = &cobra.Command{
 		}))
 
 		t := time.Now()
-		pwd, _ := helpers.GetPath()
+		pwd, err := helpers.GetPath()
+		if err != nil {
+			panic(err)
+		}
 
 		bucket := bucketS3
 		keyNameDarwin := fmt.Sprintf("%s/skipper-%s", bucketS3PathBuildsDarwin, t.Format("200601021504"))
@@ -67,7 +70,7 @@ var skipperUploadCmd = &cobra.Command{
 		fhLinux, err := os.Open(fileLinux)
 
 		if err != nil {
-			fmt.Printf("The to be uploaded file does not exist:\n%s", fileLinux)
+			fmt.Printf("The file to be uploaded does not exist:\n%s", fileLinux)
 			os.Exit(1)
 		}
 

--- a/ssm.go
+++ b/ssm.go
@@ -19,7 +19,6 @@ func listSSM(service *string) {
 	global := "global"
 	listParams, _ := ssm.GetParameters(&global)
 	green := color.New(color.FgGreen).SprintFunc()
-	//whiteslim := color.New(color.FgWhite).SprintFunc()
 	whitebold := color.New(color.FgWhite, color.Bold).SprintFunc()
 	fmt.Printf("%s %s %s\n", "===", whitebold(global), whitebold("Config Vars"))
 	for v := range listParams {
@@ -37,14 +36,9 @@ func listSSM(service *string) {
 
 }
 
-// statusCmd represents the status command
 var ssmindexCmd = &cobra.Command{
 	Use:   "ssm",
-	Short: "Docker commands",
-	Long:  "This command has subcommand",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("This command has subcommands ")
-	},
+	Short: "SSM commands",
 }
 
 var ssmListCmd = &cobra.Command{
@@ -119,7 +113,6 @@ var ssmHistoryCmd = &cobra.Command{
 
 		ssm := ssmclient.New()
 		green := color.New(color.FgGreen).SprintFunc()
-		//whiteslim := color.New(color.FgWhite).SprintFunc()
 		whitebold := color.New(color.FgWhite, color.Bold).SprintFunc()
 
 		listParams, _ := ssm.GetParameterHistory(&stripped, &name)

--- a/update.go
+++ b/update.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	//"bytes"
-
 	"strings"
 
 	"github.com/blinkist/skipper/aws/ecsclient"


### PR DESCRIPTION
The main important change in this PR is the SSH tunneling adjustment; instead
of manually forwarding a Unix socket file through the SSH connection, we
instead plumb the SSH connection through to the dialer of the Docker client.
This effectively eliminates the race condition we were experiencing when
copying data over that stream to/from the Unix domain socket.

The patchset also involves a number of cleanup changes from problems
enconutered while getting the project built and running smoothly. In addition
it slowly starts to make some of the golang slightly more idiomatic.